### PR TITLE
Add --exclude DIR option

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,19 @@ to run the preprocessor, or `cc` if unset.  Another way to specify the compiler
 is using the `--use-cc CC` option which takes precedence over the environment
 variable.
 
+## Specifying a JSON output format ##
+
+**Experimental**: with `--format json` Centrinel will write analysis results as
+a JSON blob (whose format is quite in flux at the moment).  The blob may be
+consumed with, for example
+[centrinel-report](https://github.com/lambdageek/centrinel-report)
+
+## Excluding directories from analysis ##
+
+With `--exclude DIR` (which may be specified multiple times), any input files
+that are in `DIR` or one of its subdirectories will not be analyzed.  (Works
+both with `-- CFLAGS CFILE` mode and with `--project JSON_FILE`).
+
 ## What works ##
 
 * Region annotations on struct definitions (specified by

--- a/centrinel.cabal
+++ b/centrinel.cabal
@@ -69,6 +69,7 @@ library
                        containers >= 0.5.6.2,
                        contravariant >= 1.4,
                        directory >= 1.2.3,
+                       filepath >= 1.4.0.0,
                        language-c >= 0.6,
                        mtl >= 2.2.1,
                        pretty >= 1.1.2.0,

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -12,10 +12,13 @@ theParser :: ParserInfo Centrinel.Main.CentrinelCmd
 theParser =
   let
     commonOptions :: Parser Centrinel.Main.CentrinelOptions
-    commonOptions = Centrinel.Main.CentrinelOptions <$> useCCOption <*> outputMethodOptions
+    commonOptions = Centrinel.Main.CentrinelOptions <$> useCCOption <*> outputMethodOptions <*> excludeDirOption
 
     useCCOption :: Parser (Maybe FilePath)
     useCCOption = optional $ strOption (long "use-cc" <> metavar "CC" <> help "Use the given C compiler for preprocessing (Default: REAL_CC environment value or 'cc' if unset)")
+
+    excludeDirOption :: Parser [FilePath]
+    excludeDirOption = many $ strOption (long "exclude" <> metavar "DIR" <> help "Don't scan files in the given directory.  May be specified several times.")
 
     runProject :: Parser (Centrinel.Main.CentrinelOptions -> Centrinel.Main.CentrinelCmd)
     runProject = flip Centrinel.Main.RunProjectCentrinelCmd <$> strOption (long "project" <> help "Run the analysis on every file in the compilation database JSON_FILE" <> metavar "JSON_FILE")

--- a/src/Centrinel/System/RunLikeCC.hs
+++ b/src/Centrinel/System/RunLikeCC.hs
@@ -8,6 +8,7 @@ module Centrinel.System.RunLikeCC (
   , runLikeCC
   -- * Utilities
   , anySourceArgs
+  , cppArgsInputFile
   -- * Re-exported definitons
   , Preprocessor
   , GCC
@@ -19,6 +20,7 @@ import qualified Data.List
 import Data.Monoid (Any(..))
 
 import Language.C.System.Preprocess (Preprocessor(..), CppArgs)
+import qualified Language.C.System.Preprocess as Cpp
 import Language.C.System.GCC (GCC, newGCC)
 
 
@@ -61,6 +63,9 @@ prefilterCCArgs = Data.List.partition isProblem
     predicates =
       [(Data.List.isPrefixOf "-g", "-ggdb3 leaves #defines in preprocessor output")
       ]
+
+cppArgsInputFile :: CppArgs -> FilePath
+cppArgsInputFile = Cpp.inputFile
 
 -- | Returns @Any True@ iff any of the given strings looks like a source file.
 -- It uses a pretty rough heuristic: the string must not begin with a @'-'@ and


### PR DESCRIPTION
Specify directories that should not be analyzed.  Particularly useful together
with `--project compile_commands.json` from an instrumented build that captured
unwanted artifacts (such as third party libraries)

Closes #7 
