### PR TITLE
Allow __suppress(1) on declarations

### DIFF
--- a/c-examples/attrib.c
+++ b/c-examples/attrib.c
@@ -49,6 +49,8 @@ struct XPayload {
 
 typedef struct XPayload *XHandle;
 
+extern RT_KNOWN int legacy_x (X* use);
+
 /* Work around language-c 0.7 issue #32
  * (https://github.com/visq/language-c/issues/32) we can't parse
  * attributes on empty statements yet

--- a/centrinel.cabal
+++ b/centrinel.cabal
@@ -49,6 +49,7 @@ library
                        Control.Unification.IntVar.Extras,
                        Centrinel.NakedPointer,
                        Centrinel.NakedPointer.Env,
+                       Centrinel.NakedPointer.FindSuppressAttribute,
                        Centrinel.NakedPointer.InDeclarations,
                        Centrinel.NakedPointer.InDefinitions,
                        Centrinel.NakedPointer.PointerRegionScheme,

--- a/include/centrinel.h
+++ b/include/centrinel.h
@@ -28,7 +28,35 @@
 #define ___CENTRINEL__LABEL_(n) ___centrinel_label_dummy##n
 #define ___CENTRINEL__LABEL(n) ___CENTRINEL__LABEL_(n):
 
-#define __CENTRINEL_SUPPRESS_SCOPE(b) ___CENTRINEL__LABEL(__LINE__) __attribute__((__suppress(b))) ;
+/* Centrinel's __suppress(1) attribute may be used to temporarily disable checking for raw pointers into
+ * __CENTRINEL_MANAGED_REGION in the following circumstances:
+ *
+ * - If the attribute is applied to a label at the beginning of a compound
+ *   statement (a block), checking is suppressed in the block.  Checking may be
+ *   re-enabled on subparts of the suppressed scope with __suppress(0).
+ *
+ * - If the attribute is applied to a declaration (for example a function
+ *   declaration), no warning will be elicited by the declaration.  (Note
+ *   however that if the declaration is a function, the call site may still
+ *   elicit warnings for the actual arguments.)  Applying the attribute to a
+ *   declaration is primarily useful to provide deprecated legacy raw pointer
+ *   APIs that are not expected to be called.
+ */
+#define __CENTRINEL_SUPPRESS_ATTR(b) __attribute__((__suppress(b)))
+#define __CENTRINEL_SUPPRESS_SCOPE(b) ___CENTRINEL__LABEL(__LINE__) __CENTRINEL_SUPPRESS_ATTR(b) ;
+/* These helper macros expand to GNU C statement expressions - they may be
+ * useful to suppress/unsuppress checking of individual expressions.  This is
+ * particularly useful in macros to suppress checking the macro body, but
+ * re-enable checking of the arguments:
+ *
+ * For example:
+ *
+ *     #define SAFE_ACCESS(expr) __CENTRINEL_SUPPRESS(some_safe_access (__CENTRINEL_UNSUPPRESS(expr)->unsafe_field))
+ *
+ *  If expr returns a safely wrapped raw pointer, accessing the unsafe_field
+ *  would normally elicit a warning which is suppressed.  The argument "expr"
+ *  however will still be checked when the macro is used.
+ */
 #define __CENTRINEL_UNSUPPRESS(expr) ({ __CENTRINEL_SUPPRESS_SCOPE(0) (expr); })
 #define __CENTRINEL_SUPPRESS(expr) ({ __CENTRINEL_SUPPRESS_SCOPE(1) (expr); })
 

--- a/src/Centrinel/NakedPointer/FindSuppressAttribute.hs
+++ b/src/Centrinel/NakedPointer/FindSuppressAttribute.hs
@@ -1,0 +1,47 @@
+-- | Find @__attribute__((__suppress(b)))@ in a givne attribute list
+-- 
+module Centrinel.NakedPointer.FindSuppressAttribute where
+
+import Control.Applicative
+import Data.Foldable (Foldable(foldMap))
+import Data.Monoid (Alt(..))
+
+import qualified Language.C.Data.Ident as C
+import qualified Language.C.Syntax.AST as CStx
+import qualified Language.C.Syntax.Constants as CStx
+import qualified Language.C.Analysis.SemRep as CSem
+
+-- | Returns @pure b@ iff the given attribute list includes @__suppress(c)@.
+-- If @c@ is a literal constant 0, @b@ is 'False', if it is a literal constant
+-- 1, @b@ is 'True'. If the attribute is not found, returns 'empty'
+findSuppressAttribute :: Alternative f => C.Ident -> [CStx.CExpr] -> f Bool
+findSuppressAttribute ident attrArgs = do
+  case attrArgs of
+    [CStx.CConst (CStx.CIntConst i _constNi)]
+      | isSuppress ident ->
+          case CStx.getCInteger i of
+            0 -> pure False
+            1 -> pure True
+            _ -> empty
+    _ -> empty
+
+-- | Look in the given list of attributes for a @__suppress(c)@ pragma.
+-- Returns @pure (c == 1)@ where c is the argument value from the first
+-- attribute with a literal constant 0 or 1 as the argument (That is: if it
+-- finds several @_suppress(x)@ attributes that don't have a 0 or 1 literal for
+-- @x@, it'll skip them and keep going).
+findSuppressInCAttrList :: (Foldable f, Alternative g) => f CStx.CAttr -> g Bool
+findSuppressInCAttrList = getAlt . foldMap (Alt . findSuppressCAttr)
+  where
+    findSuppressCAttr (CStx.CAttr ident attrArgs _ni) = findSuppressAttribute ident attrArgs
+{-# Specialize findSuppressInCAttrList :: [CStx.CAttr] -> Maybe Bool #-}
+
+-- | Same as 'findSuppressInCAttrList' but for 'CSem.Attr' as the attribute type.
+findSuppressInSemAttrList :: (Foldable f, Alternative g) => f CSem.Attr -> g Bool
+findSuppressInSemAttrList = getAlt . foldMap (Alt . findSuppressSemAttr)
+  where
+    findSuppressSemAttr (CSem.Attr ident attrArgs _ni) = findSuppressAttribute ident attrArgs
+{-# Specialize findSuppressInSemAttrList :: [CSem.Attr] -> Maybe Bool #-}
+
+isSuppress:: C.Ident -> Bool
+isSuppress ident = C.identToString ident == "__suppress"


### PR DESCRIPTION
Allow declarations of functions and variables to be annotated with a `__attribute__((__suppress(1)))` to prevent a naked pointer warning.

The suppression only applies to the declaration, not to the uses of the functions or declarations.

This is useful in order to mark legacy APIs that must provide naked pointer access, but which are not expected to be used.

Closes #12 