### PR TITLE
[RegionInference] Pick up regions of structs that do not have defns

### DIFF
--- a/c-examples/fwd.c
+++ b/c-examples/fwd.c
@@ -1,0 +1,6 @@
+
+typedef struct _A __CENTRINEL_MANAGED_ATTR A;
+
+void foo (A* a1, A* a2, unsigned long n);
+
+


### PR DESCRIPTION
If a header defines `SomeTypeDefName` but never gives a definition for `struct
SomeTag`, below, we should still warn about occurrences of `SomeTypeDefName *`.
```
    typedef struct SomeTag __attribute__((region(k))) SomeTypeDefName;
```

Closes #17